### PR TITLE
Add catalog entries for games 067-071

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>ゲーム・カード一覧（001–066）</title>
+<title>ゲーム・カード一覧（001–071）</title>
 <style>
   :root { --radius:12px; --shadow:0 4px 16px rgba(0,0,0,.08); }
   * { box-sizing: border-box; }
@@ -30,7 +30,7 @@
 </head>
 <body>
   <header>
-    <h1>ゲーム・カード一覧（001–066）</h1>
+    <h1>ゲーム・カード一覧（001–071）</h1>
     <div class="tools">
       <input id="q" type="search" placeholder="タイトル・カテゴリ・キーワードで検索…" aria-label="検索" />
       <span id="count" class="count"></span>
@@ -111,7 +111,12 @@
     { title: 'リズム2', category: 'action', keywords: 'リズム 音楽 ビート 2', url: 'https://titan11111.github.io/063-rizme2', icon: '🎵' },
     { title: 'ピンクマン：ドットの迷宮', category: 'action', keywords: 'ピンクマン パックマン 迷路', url: 'https://titan11111.github.io/064-pincman/', icon: '🟡' },
     { title: 'RPG4', category: 'adventure', keywords: 'RPG 冒険 物語 4', url: 'https://titan11111.github.io/065-RPG4', icon: '⚔️' },
-    { title: 'ねこクイズ：にゃんこ知識テスト', category: 'quiz', keywords: 'ねこ 猫 クイズ', url: 'https://titan11111.github.io/066-catquiz/', icon: '🐱' }
+    { title: 'ねこクイズ：にゃんこ知識テスト', category: 'quiz', keywords: 'ねこ 猫 クイズ', url: 'https://titan11111.github.io/066-catquiz/', icon: '🐱' },
+    { title: 'レースチャレンジ：サーキットスプリント', category: 'action', keywords: 'レース 車 スピード ドリフト', url: 'https://titan11111.github.io/067-race/', icon: '🏎️' },
+    { title: 'オセロバトル：白と黒の陣取り', category: 'puzzle', keywords: 'オセロ リバーシ ボード パズル', url: 'https://titan11111.github.io/068-ocero/', icon: '⚪️' },
+    { title: 'ボンバーマン：爆裂迷宮', category: 'action', keywords: 'ボンバーマン 爆弾 迷路 アクション', url: 'https://titan11111.github.io/069-bomberman/', icon: '💣' },
+    { title: '忍者スラッシュ：影の戦士', category: 'action', keywords: '忍者 ステルス アクション 刀', url: 'https://titan11111.github.io/070-ninja/', icon: '🥷' },
+    { title: '迷路アドベンチャー2：無限回廊', category: 'adventure', keywords: '迷路 冒険 パズル 探索', url: 'https://titan11111.github.io/071-meiro2/', icon: '🌀' }
   ];
 
   const grid  = document.getElementById('grid');


### PR DESCRIPTION
## Summary
- extend the catalog title range to 001–071
- add card entries for the new games 067-race, 068-ocero, 069-bomberman, 070-ninja, and 071-meiro2

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce83d7d9888330a1264db71a5eee72